### PR TITLE
Fix inconsistent dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
     - ixmp4 = ixmp4.__main__:app
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* ~[ ] Reset the build number to `0` (if the version changed)~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.


<!--
Please add any other relevant info below:
-->
#32 was merged before properly completing the checklist: we now have dependencies in our `meta.yaml` here that are inconsistent with our `pyproject.toml` in the main repo. This PR fixes these dependencies.

While going over this list, I noticed that conda doesn't let us specify extra/optional dependencies. This means that we request a few packages in `pyproject.toml` indirectly that may be missing from a conda-installed ixmp4. Specifically, this is the current list of dependencies in question:

```
    - psycopg-binary == 3.3.0.dev1; implementation_name != \"pypy\"
    - h2 >=3,<5
    - mypy >=1.7
    - types-greenlet >=2
```

I'm not sure if any of them are extremely relevant, some may also come from other dependencies, so we may be fine, but we should probably include them in our `meta.yaml` here to be explicit about this and avoid unexpected errors/breakage (though I would have to look up how to translate the first one to conda-readable specifiers).
